### PR TITLE
refactor: httpdump

### DIFF
--- a/http/httpdump/dump.go
+++ b/http/httpdump/dump.go
@@ -8,16 +8,18 @@ import (
 )
 
 type Dump struct {
-	Line   string
-	Header http.Header
-	Body   *bytes.Reader
+	Line    string
+	Header  http.Header
+	Body    *bytes.Reader
+	Trailer http.Header
 }
 
 func (d *Dump) MarshalJSON() ([]byte, error) {
 	type dump struct {
-		Line   string      `json:"line"`
-		Header http.Header `json:"headers"`
-		Body   string      `json:"body"`
+		Line    string      `json:"line"`
+		Header  http.Header `json:"headers"`
+		Body    string      `json:"body"`
+		Trailer http.Header `json:"trailer"`
 	}
 
 	d.Body.Seek(0, 0)
@@ -28,17 +30,19 @@ func (d *Dump) MarshalJSON() ([]byte, error) {
 	d.Body.Seek(0, 0)
 
 	return json.Marshal(dump{
-		Line:   d.Line,
-		Header: d.Header,
-		Body:   string(b),
+		Line:    d.Line,
+		Header:  d.Header,
+		Body:    string(b),
+		Trailer: d.Trailer,
 	})
 }
 
 func (d *Dump) UnmarshalJSON(b []byte) error {
 	type dump struct {
-		Line   string      `json:"line"`
-		Header http.Header `json:"headers"`
-		Body   string      `json:"body"`
+		Line    string      `json:"line"`
+		Header  http.Header `json:"headers"`
+		Body    string      `json:"body"`
+		Trailer http.Header `json:"trailer"`
 	}
 
 	var a dump
@@ -49,6 +53,7 @@ func (d *Dump) UnmarshalJSON(b []byte) error {
 	d.Line = a.Line
 	d.Header = a.Header
 	d.Body = bytes.NewReader([]byte(a.Body))
+	d.Trailer = a.Trailer
 
 	return nil
 }

--- a/http/httpdump/dump_test.go
+++ b/http/httpdump/dump_test.go
@@ -19,6 +19,7 @@ func TestDump(t *testing.T) {
 			"Content-Length":  []string{"17"},
 			"Accept-Encoding": []string{"gzip"},
 			"Content-Type":    []string{"application/json"},
+			"Trailer":         []string{"My-Trailer"},
 		},
 		Body: bytes.NewReader([]byte(`{"name": "Alice"}`)),
 	}

--- a/http/httpdump/httpdump.go
+++ b/http/httpdump/httpdump.go
@@ -5,16 +5,19 @@ import (
 	"encoding/json"
 )
 
-// NormalizeNewlines normalizes \r\n (windows) and \r (mac)
-// into \n (unix)
-// Reference [here].
-// [here]: https://www.programming-books.io/essential/go/normalize-newlines-1d3abcf6f17c4186bb9617fa14074e48
-func NormalizeNewlines(d []byte) []byte {
-	// replace CR LF \r\n (windows) with LF \n (unix)
-	d = bytes.Replace(d, []byte{13, 10}, []byte{10}, -1)
-	// replace CF \r (mac) with LF \n (unix)
-	d = bytes.Replace(d, []byte{13}, []byte{10}, -1)
-	return d
+func normalizeNewlines(b []byte) []byte {
+	b = bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+	b = bytes.ReplaceAll(b, []byte("\r"), []byte("\n"))
+	b = bytes.TrimSpace(b)
+	return b
+}
+
+func denormalizeNewlines(b []byte) []byte {
+	b = bytes.TrimSpace(b)
+	parts := bytes.Split(b, []byte("\n"))
+	b = bytes.Join(parts, []byte("\r\n"))
+	b = append(b, []byte("\r\n\r\n")...)
+	return b
 }
 
 func prettyBytes(b []byte) ([]byte, error) {

--- a/http/httpdump/request_test.go
+++ b/http/httpdump/request_test.go
@@ -1,7 +1,8 @@
 package httpdump_test
 
 import (
-	"encoding/json"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/alextanhongpin/core/http/httpdump"
@@ -9,83 +10,26 @@ import (
 )
 
 func TestRequestUnmarshal(t *testing.T) {
-	b := []byte(`POST /bar HTTP/1.1
-Host: 127.0.0.1:61663
-User-Agent: Go-http-client/1.1
-Content-Length: 17
-Accept-Encoding: gzip
-Content-Type: application/json
-
-{
- "bar": "baz"
-}`)
+	p := strings.NewReader(`{"foo": "bar"}`)
+	r := httptest.NewRequest("POST", "/", p)
 
 	t.Run("text", func(t *testing.T) {
+		req, err := httpdump.NewRequest(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := req.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		r := new(httpdump.Request)
 		if err := r.UnmarshalText(b); err != nil {
 			t.Fatal(err)
 		}
 
 		got, err := r.MarshalText()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		want := b
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatalf("want(+), got (-):\n%s", diff)
-		}
-	})
-
-	t.Run("json", func(t *testing.T) {
-		r := new(httpdump.Request)
-		if err := r.UnmarshalText(b); err != nil {
-			t.Fatal(err)
-		}
-
-		j, err := json.Marshal(r)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var jr httpdump.Request
-		if err := json.Unmarshal(j, &jr); err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := jr.MarshalText()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		want := b
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatalf("want(+), got (-):\n%s", diff)
-		}
-	})
-
-	t.Run("parse", func(t *testing.T) {
-		r := new(httpdump.Request)
-		if err := r.UnmarshalText(b); err != nil {
-			t.Fatal(err)
-		}
-
-		req, err := httpdump.NewRequest(r.Request)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		j, err := json.Marshal(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var jr httpdump.Request
-		if err := json.Unmarshal(j, &jr); err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := jr.MarshalText()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/http/httpdump/response.go
+++ b/http/httpdump/response.go
@@ -4,14 +4,38 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"runtime"
 	"strconv"
 	"strings"
 )
+
+func logError(err error) (b bool) {
+	//if _, ok := os.LookupEnv("DEBUG"); !ok {
+	//return
+	//}
+	if err != nil {
+		pkg := "github.com/alextanhongpin"
+		pretty := func(s string) string {
+			parts := strings.Split(s, pkg)
+			part := parts[len(parts)-1]
+			return strings.TrimPrefix(part, "/")
+		}
+		// notice that we're using 1, so it will actually log the where
+		// the error happened, 0 = this function, we don't want that.
+
+		pc, filename, line, _ := runtime.Caller(1)
+		fn := runtime.FuncForPC(pc).Name()
+
+		fmt.Printf("%s[%s:%d]: %v\n", pretty(fn), pretty(filename), line, err)
+		b = true
+	}
+
+	return
+}
 
 type Response struct {
 	*http.Response
@@ -33,10 +57,12 @@ func NewResponse(r *http.Response) (*Response, error) {
 func (r *Response) Parse() error {
 	res, err := normalizeResponse(r.Response)
 	if err != nil {
+		logError(err)
 		return err
 	}
 	dump, err := responseToDump(res)
 	if err != nil {
+		logError(err)
 		return err
 	}
 
@@ -47,55 +73,24 @@ func (r *Response) Parse() error {
 }
 
 func (r *Response) UnmarshalText(b []byte) error {
-	b = bytes.TrimSpace(b)
+	b = normalizeNewlines(b)
+	b = denormalizeNewlines(b)
 
-	var res *http.Response
-
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	var bb bytes.Buffer
-
-	sections := 3
-	for i := 0; i < sections; i++ {
-	scan:
-		for scanner.Scan() {
-			text := scanner.Text()
-			if len(text) == 0 {
-				break scan
-			}
-
-			switch i {
-			case 0:
-				var err error
-				res, err = parseResponseLine(strings.NewReader(text))
-				if err != nil {
-					return err
-				}
-
-				break scan
-			case 1:
-				k, v, ok := strings.Cut(text, ": ")
-				if !ok {
-					return errors.New("invalid response header format")
-				}
-				res.Header.Add(k, v)
-			case 2:
-				bb.WriteString(text)
-				bb.WriteString("\n")
-			}
-		}
+	res, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(b)), nil)
+	if err != nil {
+		logError(err)
+		return err
 	}
 
-	body := bytes.NewReader(bytes.TrimSpace(bb.Bytes()))
-	res.Body = io.NopCloser(body)
-
-	var err error
 	res, err = normalizeResponse(res)
 	if err != nil {
+		logError(err)
 		return err
 	}
 
 	dump, err := responseToDump(res)
 	if err != nil {
+		logError(err)
 		return err
 	}
 
@@ -108,11 +103,11 @@ func (r *Response) UnmarshalText(b []byte) error {
 func (r *Response) MarshalText() ([]byte, error) {
 	res, err := httputil.DumpResponse(r.Response, true)
 	if err != nil {
+		logError(err)
 		return nil, err
 	}
 
-	res = NormalizeNewlines(res)
-	res = bytes.TrimSpace(res)
+	res = normalizeNewlines(res)
 
 	return res, nil
 }
@@ -124,12 +119,14 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 func (r *Response) UnmarshalJSON(b []byte) error {
 	var dump Dump
 	if err := json.Unmarshal(b, &dump); err != nil {
+		logError(err)
 		return err
 	}
 
 	res, err := dumpToResponse(&dump)
 	if err != nil {
-		return err
+		logError(err)
+		return fmt.Errorf("UnmarshalJSON: %w", err)
 	}
 
 	r.Dump = dump
@@ -142,14 +139,20 @@ func normalizeResponse(res *http.Response) (*http.Response, error) {
 	// Prettify the request body.
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, err
+		logError(err)
+		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 
-	b, err = prettyBytes(b)
-	if err != nil {
-		return nil, err
+	if len(res.Trailer) == 0 {
+		b, err = prettyBytes(b)
+		if err != nil {
+			logError(err)
+			return nil, fmt.Errorf("failed to prettify body: %w", err)
+		}
 	}
 
+	//b = denormalizeNewlines(b)
+	//b = bytes.TrimSpace(b)
 	res.Body = io.NopCloser(bytes.NewReader(b))
 
 	return res, nil
@@ -158,11 +161,13 @@ func normalizeResponse(res *http.Response) (*http.Response, error) {
 func dumpToResponse(dump *Dump) (*http.Response, error) {
 	res, err := parseResponseLine(strings.NewReader(dump.Line))
 	if err != nil {
+		logError(err)
 		return nil, err
 	}
 
 	res.Header = dump.Header.Clone()
 	res.Body = io.NopCloser(dump.Body)
+	res.Trailer = dump.Trailer.Clone()
 
 	return normalizeResponse(res)
 }
@@ -172,16 +177,18 @@ func responseToDump(res *http.Response) (*Dump, error) {
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, err
+		logError(err)
+		return nil, fmt.Errorf("responseToDump: %w", err)
 	}
 
 	body := bytes.NewReader(b)
 	res.Body = io.NopCloser(body)
 
 	return &Dump{
-		Line:   resLine,
-		Header: res.Header.Clone(),
-		Body:   body,
+		Line:    resLine,
+		Header:  res.Header.Clone(),
+		Body:    body,
+		Trailer: res.Trailer.Clone(),
 	}, nil
 }
 
@@ -209,6 +216,7 @@ func parseResponseLine(r io.Reader) (*http.Response, error) {
 		&w.ProtoMinor,
 		&w.StatusCode,
 	); err != nil {
+		logError(err)
 		return nil, err
 	}
 	w.Header = make(http.Header)

--- a/http/httpdump/response.go
+++ b/http/httpdump/response.go
@@ -143,16 +143,14 @@ func normalizeResponse(res *http.Response) (*http.Response, error) {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 
-	if len(res.Trailer) == 0 {
-		b, err = prettyBytes(b)
-		if err != nil {
-			logError(err)
-			return nil, fmt.Errorf("failed to prettify body: %w", err)
-		}
+	b, err = prettyBytes(b)
+	if err != nil {
+		logError(err)
+		return nil, fmt.Errorf("failed to prettify body: %w", err)
 	}
 
-	//b = denormalizeNewlines(b)
-	//b = bytes.TrimSpace(b)
+	b = denormalizeNewlines(b)
+	b = bytes.TrimSpace(b)
 	res.Body = io.NopCloser(bytes.NewReader(b))
 
 	return res, nil

--- a/http/httpdump/response.go
+++ b/http/httpdump/response.go
@@ -8,15 +8,17 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
 )
 
 func logError(err error) (b bool) {
-	//if _, ok := os.LookupEnv("DEBUG"); !ok {
-	//return
-	//}
+	if _, ok := os.LookupEnv("DEBUG"); !ok {
+		return
+	}
+
 	if err != nil {
 		pkg := "github.com/alextanhongpin"
 		pretty := func(s string) string {
@@ -24,9 +26,9 @@ func logError(err error) (b bool) {
 			part := parts[len(parts)-1]
 			return strings.TrimPrefix(part, "/")
 		}
-		// notice that we're using 1, so it will actually log the where
-		// the error happened, 0 = this function, we don't want that.
 
+		// Notice that we're using 1, so it will actually log the where
+		// the error happened, 0 = this function, we don't want that.
 		pc, filename, line, _ := runtime.Caller(1)
 		fn := runtime.FuncForPC(pc).Name()
 

--- a/http/httpdump/response_test.go
+++ b/http/httpdump/response_test.go
@@ -20,8 +20,10 @@ Trailer: My-Trailer
 Content-Type: application/json
 Date: Tue, 04 Jul 2023 15:52:27 GMT
 
-12
-{"hello": "world"}
+17
+{
+ "hello": "world"
+}
 0
 My-Trailer: my-val`)
 

--- a/test/testutil/testdata/TestHTTPServer.http
+++ b/test/testutil/testdata/TestHTTPServer.http
@@ -1,5 +1,5 @@
 POST /bar HTTP/1.1
-Host: 127.0.0.1:58485
+Host: 127.0.0.1:63010
 User-Agent: Go-http-client/1.1
 Content-Length: 17
 Accept-Encoding: gzip

--- a/test/testutil/testdata/TestHTTPTrailer.http
+++ b/test/testutil/testdata/TestHTTPTrailer.http
@@ -1,0 +1,21 @@
+GET / HTTP/1.1
+Host: 127.0.0.1:49235
+User-Agent: Go-http-client/1.1
+Accept-Encoding: gzip
+
+
+###
+
+
+HTTP/1.1 200 OK
+Transfer-Encoding: chunked
+Trailer: My-Trailer
+Content-Type: application/json
+Date: Tue, 04 Jul 2023 18:09:02 GMT
+
+15
+{
+ "hello": "world"
+}
+0
+My-Trailer: my-val

--- a/test/testutil/testdata/TestHTTPTrailer.http
+++ b/test/testutil/testdata/TestHTTPTrailer.http
@@ -1,5 +1,5 @@
 GET / HTTP/1.1
-Host: 127.0.0.1:49235
+Host: 127.0.0.1:49609
 User-Agent: Go-http-client/1.1
 Accept-Encoding: gzip
 
@@ -11,9 +11,9 @@ HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 Trailer: My-Trailer
 Content-Type: application/json
-Date: Tue, 04 Jul 2023 18:09:02 GMT
+Date: Tue, 04 Jul 2023 18:52:34 GMT
 
-15
+17
 {
  "hello": "world"
 }

--- a/test/testutil/testdata/TestLoadURLAndCompare.json
+++ b/test/testutil/testdata/TestLoadURLAndCompare.json
@@ -2,5 +2,5 @@
  "name": "John Appleseed",
  "age": 13,
  "isMarried": true,
- "bornAt": "2023-06-22T00:25:22.725361+08:00"
+ "bornAt": "2023-07-01T12:25:36.000372+08:00"
 }


### PR DESCRIPTION
**Description**

Refactor httpdump to use standard packages


**Changes**
- Use the standard package `http.ReadRequest` and `http.ReadResponse` to parse the request and response dump respectively
- Add basic logging (to be improved)
