### PR TITLE
fix(dsync/idempotent): fix lock expiry and unlock cancelled

### DIFF
--- a/dsync/idempotent/go.mod
+++ b/dsync/idempotent/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/sync v0.7.0
 )
 
 require (
@@ -39,7 +40,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/dsync/idempotent/idempotent_test.go
+++ b/dsync/idempotent/idempotent_test.go
@@ -41,7 +41,7 @@ func TestPrivateLoad(t *testing.T) {
 	t.Run("when key does not exist", func(t *testing.T) {
 		cleanup(t)
 
-		_, err := idem.load(ctx, "hello", "world")
+		_, err := idem.load(ctx, t.Name(), "world")
 		// Assert that the error is redis.Nil, indicating that the key does not
 		// exist.
 		assert.ErrorIs(t, err, redis.Nil)
@@ -51,8 +51,9 @@ func TestPrivateLoad(t *testing.T) {
 		cleanup(t)
 
 		a := assert.New(t)
-		a.Nil(client.Set(ctx, "hello", uuid.New().String(), 0).Err())
-		_, err := idem.load(ctx, "hello", "world")
+		key := t.Name()
+		a.Nil(client.Set(ctx, key, uuid.New().String(), 0).Err())
+		_, err := idem.load(ctx, key, "world")
 		// Assert that the error is ErrRequestInFlight, indicating that a request
 		// is already in flight for the key.
 		a.ErrorIs(err, ErrRequestInFlight)
@@ -63,9 +64,10 @@ func TestPrivateLoad(t *testing.T) {
 
 		a := assert.New(t)
 
+		key := t.Name()
 		reqHash := hash([]byte(`"world"`))
-		a.Nil(client.Set(ctx, "hello", fmt.Sprintf(`{"request": %q, "response": 42}`, reqHash), 0).Err())
-		v, err := idem.load(ctx, "hello", "world")
+		a.Nil(client.Set(ctx, key, fmt.Sprintf(`{"request": %q, "response": 42}`, reqHash), 0).Err())
+		v, err := idem.load(ctx, key, "world")
 		a.Nil(err)
 		a.Equal(42, v)
 	})
@@ -74,8 +76,9 @@ func TestPrivateLoad(t *testing.T) {
 		cleanup(t)
 
 		a := assert.New(t)
-		a.Nil(client.Set(ctx, "hello", `{"request": "world", "response": 42}`, 0).Err())
-		_, err := idem.load(ctx, "hello", "not-world")
+		key := t.Name()
+		a.Nil(client.Set(ctx, key, `{"request": "world", "response": 42}`, 0).Err())
+		_, err := idem.load(ctx, key, "not-world")
 		// Assert that the error is ErrRequestMismatch, indicating that the request
 		// does not match the stored request for the key.
 		a.ErrorIs(err, ErrRequestMismatch)
@@ -100,38 +103,39 @@ func TestPrivateLockUnlock(t *testing.T) {
 	t.Run("when lock success", func(t *testing.T) {
 		cleanup(t)
 
-		ok, err := idem.lock(ctx, "hello", []byte("world"))
+		key := t.Name()
+		ok, err := idem.lock(ctx, key, []byte("world"))
 		assert.Nil(t, err, "expected error to be nil")
 		assert.True(t, ok, "expected lock to succeed")
 
 		// Check the lock TTL.
-		lockTTL := client.PTTL(ctx, "hello").Val()
+		lockTTL := client.PTTL(ctx, key).Val()
 		assert.True(t, 100*time.Millisecond-lockTTL < 10*time.Millisecond, "expected lock TTL to be close to 100ms")
 
 		t.Run("when lock second time", func(t *testing.T) {
-			ok, err = idem.lock(ctx, "hello", []byte("world"))
+			ok, err = idem.lock(ctx, key, []byte("world"))
 			assert.Nil(t, err, "expected error to be nil")
 			assert.False(t, ok, "then it will fail to lock")
 			// Verify that the lock is still held by the first request
-			lockValue, err := client.Get(ctx, "hello").Bytes()
+			lockValue, err := client.Get(ctx, key).Bytes()
 			assert.Nil(t, err, "expected error to be nil")
 			assert.Equal(t, []byte("world"), lockValue, "expected lock value to be 'world'")
 		})
 
 		t.Run("when unlock failed with wrong key", func(t *testing.T) {
-			err := idem.unlock(ctx, "hello", []byte("wrong-key"))
-			assert.ErrorIs(t, err, ErrKeyNotFound, "expected error to be ErrKeyNotFound")
+			err := idem.unlock(ctx, key, []byte("wrong-key"))
+			assert.ErrorIs(t, err, ErrKeyReleased, "expected error to be ErrKeyReleased")
 
-			val, err := client.Get(ctx, "hello").Result()
+			val, err := client.Get(ctx, key).Result()
 			assert.Nil(t, err, "expected error to be nil")
 			assert.Equal(t, "world", val, "expected lock value to remain unchanged")
 		})
 
 		t.Run("when unlock success", func(t *testing.T) {
-			err := idem.unlock(ctx, "hello", []byte("world"))
+			err := idem.unlock(ctx, key, []byte("world"))
 			assert.Nil(t, err, "expected error to be nil")
 
-			_, err = client.Get(ctx, "hello").Result()
+			_, err = client.Get(ctx, key).Result()
 			assert.ErrorIs(t, err, redis.Nil, "expected lock to be released")
 		})
 	})
@@ -156,14 +160,16 @@ func TestPrivateReplace(t *testing.T) {
 		cleanup(t)
 
 		a := assert.New(t)
+		key := t.Name()
 
 		// Set a value to be replaced.
-		a.Nil(client.Set(ctx, "hello", "world", 0).Err())
+		a.Nil(client.Set(ctx, key, "world", 0).Err())
 
-		err := idem.replace(ctx, "hello", []byte("invalid-old-value"), "new-value")
-		a.ErrorIs(err, ErrKeyNotFound, "expected error to be ErrKeyNotFound")
+		err := idem.replace(ctx, key, []byte("invalid-old-value"), "new-value")
+		// The key should be released.
+		a.ErrorIs(err, ErrKeyReleased)
 
-		v, err := client.Get(ctx, "hello").Result()
+		v, err := client.Get(ctx, key).Result()
 		a.Nil(err, "expected error to be nil")
 		a.Equal("world", v, "then the value stays the same")
 	})
@@ -172,21 +178,44 @@ func TestPrivateReplace(t *testing.T) {
 		cleanup(t)
 
 		a := assert.New(t)
+		key := t.Name()
 
 		// Set a value to be replaced.
-		a.Nil(client.Set(ctx, "hello", "world", 0).Err())
+		a.Nil(client.Set(ctx, key, "world", 0).Err())
 
-		err := idem.replace(ctx, "hello", []byte("world"), "new-value")
+		err := idem.replace(ctx, key, []byte("world"), "new-value")
 		a.Nil(err, "expected error to be nil")
 
-		v, err := client.Get(ctx, "hello").Result()
+		v, err := client.Get(ctx, key).Result()
 		a.Nil(err, "expected error to be nil")
 		a.Equal(`"new-value"`, v, "then the value will be replaced")
 
 		// Check the updated TTL.
-		updatedTTL := client.PTTL(ctx, "hello").Val()
+		updatedTTL := client.PTTL(ctx, key).Val()
 		a.True(200*time.Millisecond-updatedTTL < 10*time.Millisecond, "expected updated TTL to be close to 200ms")
 	})
+}
+
+// TestSlow test the scenario where the callback function takes a longer time
+// than the lock expiry, and the lock expired before the callback function
+// completes.
+// We expect the lock to be refresh periodically.
+func TestSlow(t *testing.T) {
+	client := setupRedis(t)
+
+	idem := New[string, int](client, &Option{
+		LockTTL: 100 * time.Millisecond,
+		KeepTTL: 200 * time.Millisecond,
+	})
+	fn := func(ctx context.Context, req string) (int, error) {
+		// slow function
+		time.Sleep(250 * time.Millisecond)
+		return 42, nil
+	}
+	_, err := idem.Do(ctx, t.Name(), fn, "world")
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func setupRedis(t *testing.T) *redis.Client {


### PR DESCRIPTION
## Summary

There are two major issue with the current implementation
- the lock expires before the new value is stored
- the unlock is not executed due to context cancellation

## Changes Made

- add refresh mechanism to periodically extend the lock for as long as the callback is not completed
- remove context cancellation in the **unlock** mechanism so that it is always called
- add tests to cover these scenario

## Checklist

- [x] I have added comments to code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
