### PR TITLE
feat(sync/promise): add promise.Group

### DIFF
--- a/sync/promise/group.go
+++ b/sync/promise/group.go
@@ -1,0 +1,64 @@
+package promise
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var ErrAborted = errors.New("promise: aborted")
+
+type Group[T any] struct {
+	mu sync.Mutex
+	ps map[string]*Promise[T]
+}
+
+func NewGroup[T any]() *Group[T] {
+	return &Group[T]{
+		ps: make(map[string]*Promise[T]),
+	}
+}
+
+func (g *Group[T]) Forget(key string) bool {
+	g.mu.Lock()
+	p, ok := g.ps[key]
+	if ok {
+		delete(g.ps, key)
+		g.mu.Unlock()
+
+		// Reject to prevent goroutine leak.
+		p.Reject(fmt.Errorf("%w: key replaced", ErrAborted))
+		return true
+	}
+
+	g.mu.Unlock()
+	return false
+}
+
+func (g *Group[T]) Do(key string, fn func() (T, error)) (T, error) {
+	g.mu.Lock()
+	p, ok := g.ps[key]
+	if ok {
+		g.mu.Unlock()
+		return p.Await()
+	}
+	p = New(fn)
+	g.ps[key] = p
+	g.mu.Unlock()
+
+	return p.Await()
+}
+
+func (g *Group[T]) LoadOrStore(key string) (*Promise[T], bool) {
+	g.mu.Lock()
+	p, ok := g.ps[key]
+	if ok {
+		g.mu.Unlock()
+		return p, true
+	}
+
+	p = Deferred[T]()
+	g.ps[key] = p
+	g.mu.Unlock()
+	return p, false
+}

--- a/sync/promise/group_test.go
+++ b/sync/promise/group_test.go
@@ -1,0 +1,114 @@
+package promise_test
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/alextanhongpin/core/sync/promise"
+)
+
+// TestGroup tests that the promise is invoked only once
+// while other references waits for the promise to be
+// resolved/rejected.
+func TestGroupResolve(t *testing.T) {
+	counter := new(atomic.Int64)
+	fn := func() (int, error) {
+		counter.Add(1)
+		return 42, nil
+	}
+
+	n := 10
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	g := promise.NewGroup[int]()
+
+	for range n {
+		go func() {
+			defer wg.Done()
+
+			n, err := g.Do(t.Name(), fn)
+			if err != nil {
+				t.Error(err)
+			}
+			if want, got := 42, n; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+		}()
+	}
+
+	wg.Wait()
+	if want, got := int64(1), counter.Load(); want != got {
+		t.Fatalf("want %d, got %d", want, got)
+	}
+}
+
+func TestGroupReject(t *testing.T) {
+	wantErr := errors.New("want error")
+
+	counter := new(atomic.Int64)
+	fn := func() (int, error) {
+		counter.Add(1)
+		return 0, wantErr
+	}
+
+	n := 10
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	g := promise.NewGroup[int]()
+
+	for range n {
+		go func() {
+			defer wg.Done()
+
+			_, err := g.Do(t.Name(), fn)
+			if !errors.Is(err, wantErr) {
+				t.Error(err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	if want, got := int64(1), counter.Load(); want != got {
+		t.Fatalf("want %d, got %d", want, got)
+	}
+}
+
+// TestGroupForget tests that the existing promise is
+// rejected first before deleting to prevent goroutine
+// leak.
+func TestGroupForget(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	g := promise.NewGroup[int]()
+	p, loaded := g.LoadOrStore(t.Name())
+	if loaded {
+		t.Fatal("want promise to be stored")
+	}
+
+	p, loaded = g.LoadOrStore(t.Name())
+	if !loaded {
+		t.Fatal("want promise to be loaded")
+	}
+
+	// Wait in a separate goroutine.
+	go func() {
+		defer wg.Done()
+
+		_, err := p.Await()
+		if !errors.Is(err, promise.ErrAborted) {
+			t.Error(err)
+		}
+	}()
+
+	forgotten := g.Forget(t.Name())
+	if !forgotten {
+		t.Fatal("want promise key to be forgotten")
+	}
+
+	wg.Wait()
+}

--- a/sync/promise/promise.go
+++ b/sync/promise/promise.go
@@ -29,12 +29,7 @@ func New[T any](fn func() (T, error)) *Promise[T] {
 	p := Deferred[T]()
 
 	go func() {
-		v, err := fn()
-		if err != nil {
-			p.Reject(err)
-		} else {
-			p.Resolve(v)
-		}
+		p.Wait(fn())
 	}()
 
 	return p
@@ -60,6 +55,16 @@ func (p *Promise[T]) Result() Result[T] {
 	p.wg.Wait()
 
 	return Result[T]{Data: p.data, Err: p.err}
+}
+
+func (p *Promise[T]) Wait(v T, err error) (T, error) {
+	if err != nil {
+		p.Reject(err)
+	} else {
+		p.Resolve(v)
+	}
+
+	return p.Await()
 }
 
 func (p *Promise[T]) Await() (T, error) {


### PR DESCRIPTION
## Summary

add new `promise.Wait` method and `promise.Group` for caching promises.

## Changes Made

closes #18 

## Checklist

- [x] I have added comments to code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
